### PR TITLE
Updated Gated IaC Pipeline Stack & Rename Default Branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,7 @@ pipeline {
         }
         stage('Apply Terraform Plan') {
             when {
-                branch 'master'
+                branch 'main'
             } 
             steps {
                 sh label: 'Apply Terraform plan changes', script: 'make apply'
@@ -43,7 +43,7 @@ pipeline {
         }
         stage('Integration Tests') {
             when {
-                branch 'master'
+                branch 'main'
             }
             steps {
                 sleep(time:30, unit:"SECONDS") // Wait 30 seconds for DDNS daemon set to register new address, if applicable.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This [Terraform HCL](./main.tf) is effectively a wrapper to deploy a specific ve
 
 1. Human or automated pipeline updates Terraform HCL/variables in feature branch and submits pull request.
 1. Jenkins examines pull request, runs Terraform validation tests, then records test status and comments on pull request.
-1. Human inspects Jenkins test status and manually merges pull request into master branch.
-1. Jenkins examines master branch, repeats validation tests, applies Terraform plan in the live environment, and runs integration tests.
+1. Human inspects Jenkins test status and manually merges pull request into `main` branch.
+1. Jenkins examines `main` branch, repeats validation tests, applies Terraform plan in the live environment, and runs integration tests.
 
 Note that while it's possible to manually apply changes directly to this environment, this pipeline should be treated as the second half of the [auto environment infrastructure pipeline](https://github.com/mikeroach/iac-pipeline-auto) with all application version upgrades promoted to ensure adequate testing coverage. The idea is that with comprehensive, robust testing and rich observability metrics at each stage of developing the code powering our infrastructure and application services, we have high confidence that our work is ready to be delivered to customers when our CI/CD pipelines indicate success so we can minimize our reliance on manual steps.

--- a/gated.tfvars
+++ b/gated.tfvars
@@ -1,1 +1,2 @@
 service_aphorismophilia_version = "master-a4bae1c-92"
+k8s_preemptible                 = false # We'll reduce interruptions for our "production" env, and qualify for free tier pricing as a bonus.

--- a/gitops-helper.sh
+++ b/gitops-helper.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-# Proof-of-concept poor man's GitOps helper script.
+# Proof-of-concept budget SRE's GitOps helper script.
 # Intended to be invoked by an application's CI job after all deploy tests
-# pass in master branch, and later during multi-stage infrastructure pipelines.
+# pass in main branch, and later during multi-stage infrastructure pipelines.
 
 # Yes, this is awkward and better done with a real delivery system like Jenkins-X,
 # Weaveworks Flux, Argo CD, or Spinnaker (or one pipeline for all environments).
@@ -15,7 +15,7 @@ version="20191005.1"
 usage="
 Usage: $0 -s [service] -v [version] -u [URL] [-d] [-p]
 	-h  display this help message
-	-d  commit directly to master without a pull request branch (set GITHUB_TOKEN environment variable when using default branch mode)
+	-d  commit directly to main without a pull request branch (set GITHUB_TOKEN environment variable when using default branch mode)
 	-p  promote new version/value to gated infrastructure pipeline (Jenkins job will submit pull request)
 	-s  service (or Terraform variable key) to update
 	-u  URL detailing this update (i.e. Jenkins job of originating application pipeline)
@@ -107,15 +107,15 @@ if [ "$promote" == "yes" ] ; then
 	git add scoreboard/${service}-${version}
 	git commit -m "Add lock for update of $service to $version"
 	git push -u origin scoreboard
-	git checkout master
-	git reset --hard origin/master
+	git checkout main
+	git reset --hard origin/main
 fi
 
-# Create a new branch if we're operating in pull request mode, otherwise update master directly.
+# Create a new branch if we're operating in pull request mode, otherwise update main directly.
 if [ "$git_mode" == "branch" ] ; then
 	git checkout -b ${service}-${version}
 else
-	git checkout master
+	git checkout main
 fi
 
 # Update component version with cutting edge DevOps string manipulation techniques.
@@ -128,10 +128,10 @@ else
 	git commit -m "Request update of $service to $version"
 fi
 
-# Push our branch and submit pull request if operating in pull request mode, otherwise update master directly.
+# Push our branch and submit pull request if operating in pull request mode, otherwise update main directly.
 if [ "$git_mode" == "branch" ] ; then
 	git push -u origin ${service}-${version}
 	hub pull-request -m "Request update of $service to $version" -m "Details about this version are available at: $job_url"
 else
-	git push -u origin master
+	git push -u origin main
 fi

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ terraform {
 }
 
 module "environment-gated" {
-  source                            = "github.com/mikeroach/iac-template-pipeline?ref=v17"
+  source                            = "github.com/mikeroach/iac-template-pipeline?ref=v3"
   dns_hostname                      = var.dns_hostname
   dns_domain                        = var.dns_domain
   dockerhub_credentials             = var.dockerhub_credentials


### PR DESCRIPTION
This PR:

* Updates the repository's default branch to `main` in code and documentation to embrace recommended inclusive terminology per [IETF Internet-Draft draft-knodel-terminology-12](https://datatracker.ietf.org/doc/draft-knodel-terminology/).
* Applies the latest IaC template stack to receive 3 years' worth of updates as described in https://github.com/mikeroach/iac-template-pipeline/pull/1 and https://github.com/mikeroach/iac-template-pipeline/pull/2 .