### PR TITLE
Use Non-Preemptible Nodes in Gated Cluster

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -16,6 +16,7 @@ module "environment-gated" {
   iac_bootstrap_tfstate_bucket      = var.iac_bootstrap_tfstate_bucket
   iac_bootstrap_tfstate_prefix      = var.iac_bootstrap_tfstate_prefix
   iac_bootstrap_tfstate_credentials = var.iac_bootstrap_tfstate_credentials
+  k8s_preemptible                   = var.k8s_preemptible
   subnet_cidr                       = var.subnet_cidr
   service_aphorismophilia_namespace = var.service_aphorismophilia_namespace
   service_aphorismophilia_version   = var.service_aphorismophilia_version


### PR DESCRIPTION
This PR configures the gated GKE cluster to use non-preemptible nodes as intended per #2 by passing the defined `k8s_preemptible` variables into the environment module. This way, our gated environment will qualify for the [GCP Free Tier's e2-micro instance hours](https://cloud.google.com/free/docs/free-cloud-features#compute) and experience fewer interruptions.